### PR TITLE
Adding major-tagger action

### DIFF
--- a/.github/workflows/action-major-tag.yml
+++ b/.github/workflows/action-major-tag.yml
@@ -1,0 +1,15 @@
+---
+name: Action Major Tag
+on:
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
+  workflow_dispatch:
+
+jobs:
+  new-major-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Action Major Tagger
+        uses: discoverygarden/action-major-tag@main
+        with:
+          prefix: v

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -11,3 +11,7 @@ jobs:
     runs-on: ubuntu-latest
       - name: Run Semantic Version tagging action
         uses: discoverygarden/auto-semver@v1
+      - name: Update Major Tag
+        uses: discoverygarden/action-major-tag@main
+        with:
+          prefix: 'v'


### PR DESCRIPTION
Exists in two separate workflows:
- action-major-tag
-- Exists here to cover the case where a user manually generates a new tag (should be rare, but could occur, especially if a tag is forgotten).
- semver
-- Captures the newly generated tag generated as part of the `auto-semver` workflow and generates a new major tag from it.